### PR TITLE
Remove dependency to failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comedy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Adam Gashlin <agashlin@mozilla.com>"]
 description = "Windows error handling, COM, and handles"
 keywords = ["windows", "com", "win32"]
@@ -10,14 +10,6 @@ repository = "https://github.com/agashlin/comedy-rs"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
-
-[dependencies.failure]
-version = "0.1.3"
-features = ["derive"]
-default_features = false
-
-[dependencies.failure_derive]
-version = "0.1.3"
 
 [dependencies.winapi]
 version = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comedy"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Adam Gashlin <agashlin@mozilla.com>"]
 description = "Windows error handling, COM, and handles"
 keywords = ["windows", "com", "win32"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,9 +6,8 @@
 
 //! Wrap several flavors of Windows error into a `Result`.
 
+use std::error::Error;
 use std::fmt;
-
-use failure::Fail;
 
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::winerror::{
@@ -17,7 +16,7 @@ use winapi::shared::winerror::{
 use winapi::um::errhandlingapi::GetLastError;
 
 /// An error code, optionally with information about the failing call.
-#[derive(Clone, Debug, Eq, Fail, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ErrorAndSource<T: ErrorCode> {
     code: T,
     function: Option<&'static str>,
@@ -89,6 +88,8 @@ where
         Ok(())
     }
 }
+
+impl<T> Error for ErrorAndSource<T> where T: ErrorCode {}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FileLine(pub &'static str, pub u32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 //!
 //! See macros for examples.
 
-extern crate failure;
-extern crate failure_derive;
 extern crate winapi;
 
 pub mod com;


### PR DESCRIPTION
[failure](https://github.com/rust-lang-nursery/failure) crate has been long deprecated, and I'm [trying](https://bugzilla.mozilla.org/show_bug.cgi?id=1681898) to remove all its usage from m-c.

After inspecting this crate, it seems to me that `Fail` actually has nothing to do in this crate, as you've already implemented `Display` anyway, so I simply replaced it with an `impl Error`. This shouldn't cause any breakage, because `Fail` is implemented for all `Error`, and thus any downstream crates still using `failure` will keep seeing the given type implements `Fail`.